### PR TITLE
MKCD-41

### DIFF
--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -15,26 +15,29 @@ import {
   Button,
 } from "govuk-react";
 import React, { useState, useEffect } from "react";
+import DatePicker from "react-datepicker";
+import "react-datepicker/dist/react-datepicker.css";
 
 export default function FirstPage() {
   const [firstName, setFirstName] = useState("");
-  const [middleName, setMiddleName] = useState("");
   const [lastName, setLastname] = useState("");
   const [prisonerNumber, setPrisonerNumber] = useState("");
   const [prisonName, setPrisonName] = useState("");
+  const [dateOfBirth, setDateOfBirth] = useState(null);
   const [isFormValid, setIsFormValid] = useState(false);
 
-  const validateFirstName: (value?: string) => string | undefined = (value) =>
-    value ? undefined : "Please enter a first name";
-  const validateLastName: (value?: string) => string | undefined = (value) =>
-    value ? undefined : "Please enter a last name";
-  const validatePrisonName: (value?: string) => string | undefined = (value) =>
-    value ? undefined : "Please enter a prison name";
+  const validateFirstName = (value?: string) => value ? undefined : "Please enter a first name";
+  const validateLastName = (value?: string) => value ? undefined : "Please enter a last name";
+  const validatePrisonName = (value?: string) => value ? undefined : "Please enter a prison name";
+  
+  const validateDateOfBirth = (date?: Date) => {
+    if (!date) return "Please enter a date of birth";
+    if (new Date() < date) return "Date of birth cannot be in the future";
+    // Date is in the correct format as the date picker prevents invalid date formats
+    return undefined;
+  };
 
-  // prison number is a capital A followed by 4 numbers and 2 letters
-  const validatePrisonNumber: (value?: string) => string | undefined = (
-    value
-  ) => {
+  const validatePrisonNumber = (value?: string) => {
     const prisonerNumberRegex = /([A])\d{4}[A-Z]{2}/;
     let result: string | undefined;
     if (value) {
@@ -52,8 +55,9 @@ export default function FirstPage() {
       !validateFirstName(firstName) &&
       !validateLastName(lastName) &&
       !validatePrisonName(prisonName) &&
-      !validatePrisonNumber(prisonerNumber)
-    ) {
+      !validatePrisonNumber(prisonerNumber) &&
+      !validateDateOfBirth(dateOfBirth)
+    ){
       setIsFormValid(true);
     } else {
       setIsFormValid(false);
@@ -62,7 +66,7 @@ export default function FirstPage() {
 
   useEffect(() => {
     validateForm();
-  }, [firstName, lastName, middleName, prisonerNumber, prisonName]);
+  }, [firstName, lastName, prisonerNumber, prisonName, dateOfBirth]);
 
   const handleSubmit = () => {
     console.log("Button clicked");
@@ -88,37 +92,36 @@ export default function FirstPage() {
             <FormGroup>
               <Label>
                 <LabelText>Prisoner first name</LabelText>
-                <Input
-                  value={firstName}
-                  onChange={(e) => setFirstName(e.target.value)}
-                />
-              </Label>
-            </FormGroup>
-            <FormGroup>
-              <Label>
-                <LabelText>Prisoner middle name (optional)</LabelText>
-                <Input
-                  value={middleName}
-                  onChange={(e) => setMiddleName(e.target.value)}
-                />
+                <Input value={firstName} onChange={(e) => setFirstName(e.target.value)} />
               </Label>
             </FormGroup>
             <FormGroup>
               <Label>
                 <LabelText>Prisoner last name</LabelText>
-                <Input
-                  value={lastName}
-                  onChange={(e) => setLastname(e.target.value)}
-                />
+                <Input value={lastName} onChange={(e) => setLastname(e.target.value)} />
               </Label>
             </FormGroup>
             <FormGroup>
               <Label>
                 <LabelText>Prisoner number</LabelText>
                 <HintText>For example, A1234BC</HintText>
-                <Input
-                  value={prisonerNumber}
-                  onChange={(e) => setPrisonerNumber(e.target.value)}
+                <Input value={prisonerNumber} onChange={(e) => setPrisonerNumber(e.target.value)} />
+              </Label>
+            </FormGroup>
+            <FormGroup>
+              <Label>
+                <LabelText>Date of Birth</LabelText>
+                <HintText>For example, 31/01/1990</HintText>
+                <DatePicker
+                  selected={dateOfBirth}
+                  dateFormat="dd/MM/yyyy"
+                  placeholderText="DD/MM/YYYY"
+                  onChange={date => setDateOfBirth(date)}
+                  peekNextMonth
+                  showMonthDropdown
+                  showYearDropdown
+                  dropdownMode="select"
+                  maxDate={new Date()}
                 />
               </Label>
             </FormGroup>
@@ -132,79 +135,31 @@ export default function FirstPage() {
                 }}
               >
                 <option value="">select a prison</option>
-                  <option value="a81df211-95a1-47bc-9db4-866d54040121">
-                    Acklington
-                  </option>
-                  <option value="f48d069a-64e2-493a-b256-fa5a35517418">
-                    Altcourse
-                  </option>
-                  <option value="73590df1-c04c-4e7c-aabe-1af1537fa141">
-                    Ashfield
-                  </option>
-                  <option value="83308aa4-4e64-4261-aaf8-a4bfd2f45808">
-                    Askham Grange
-                  </option>
-                  <option value="18f53a03-bf7c-4f28-a825-a758c9c3b989">
-                    Aylesbury
-                  </option>
-                  <option value="8d01337b-d3bd-463b-8e90-7427c81c7ceb">
-                    Bedford
-                  </option>
-                  <option value="54393fca-8762-40dd-bc79-b4446682e6a5">
-                    Belmarsh
-                  </option>
-                  <option value="4051e8ab-1b73-4dab-a788-f103865cf24f">
-                    Berwyn
-                  </option>
-                  <option value="e42525b2-1d73-43d8-bbd7-d2f2befbce8e">
-                    Birmingham
-                  </option>
-                  <option value="064cb1e8-1ebe-4527-8f8e-d4ebfcb2cc10">
-                    Blantyre House
-                  </option>
-                  <option value="2f1e5335-90a0-4bb0-9b74-0cb3f67dfad8">
-                    Brinsford
-                  </option>
-                  <option value="f4ad82a9-dc51-4dec-bd7c-54a05daff300">
-                    Bristol
-                  </option>
-                  <option value="e5a76c9d-d565-4b4b-8d10-58ce3b05f730">
-                    Brixton
-                  </option>
-                  <option value="3ba78f1a-af9f-491c-b7b6-364fc1616bf6">
-                    Bronzefield
-                  </option>
-                  <option value="b0e51c73-358f-4fa6-b11d-4292d709fae3">
-                    Buckley Hall
-                  </option>
-                  <option value="11b3613e-105c-48da-9f98-85678059785f">
-                    Bullingdon (Convicted Only)
-                  </option>
-                  <option value="8c920312-ea31-45a2-aec8-e18d642567d6">
-                    Bullingdon (Remand Only)
-                  </option>
-                  <option value="ff6eb0ca-da69-4495-ac9d-b383e01371eb">
-                    Bure
-                  </option>
-                  <option value="0614760e-a773-49c0-a29c-35e743e72555">
-                    Cardiff
-                  </option>
-                  <option value="4d4c2f39-a7a1-4295-9cd1-f4ab416f4508">
-                    Channings Wood
-                  </option>
-                  <option value="6114c49b-0fb2-403d-bac3-b960767adf0d">
-                    Chelmsford
-                  </option>
-                  <option value="a207122a-8ac8-4afe-821f-35a421a2fb52">
-                    Coldingley
-                  </option>
-                  <option value="4464d460-6307-4085-bd76-7ea8d64f3c86">
-                    Cookham Wood
-                  </option>
-                  <option value="21c6d486-280d-4426-a1e4-7b264613dcc7">
-                    Dartmoor
-                  </option>
-                </Select>
+                <option value="a81df211-95a1-47bc-9db4-866d54040121">Acklington</option>
+                <option value="f48d069a-64e2-493a-b256-fa5a35517418">Altcourse</option>
+                <option value="73590df1-c04c-4e7c-aabe-1af1537fa141">Ashfield</option>
+                <option value="83308aa4-4e64-4261-aaf8-a4bfd2f45808">Askham Grange</option>
+                <option value="18f53a03-bf7c-4f28-a825-a758c9c3b989">Aylesbury</option>
+                <option value="8d01337b-d3bd-463b-8e90-7427c81c7ceb">Bedford</option>
+                <option value="54393fca-8762-40dd-bc79-b4446682e6a5">Belmarsh</option>
+                <option value="4051e8ab-1b73-4dab-a788-f103865cf24f">Berwyn</option>
+                <option value="e42525b2-1d73-43d8-bbd7-d2f2befbce8e">Birmingham</option>
+                <option value="064cb1e8-1ebe-4527-8f8e-d4ebfcb2cc10">Blantyre House</option>
+                <option value="2f1e5335-90a0-4bb0-9b74-0cb3f67dfad8">Brinsford</option>
+                <option value="f4ad82a9-dc51-4dec-bd7c-54a05daff300">Bristol</option>
+                <option value="e5a76c9d-d565-4b4b-8d10-58ce3b05f730">Brixton</option>
+                <option value="3ba78f1a-af9f-491c-b7b6-364fc1616bf6">Bronzefield</option>
+                <option value="b0e51c73-358f-4fa6-b11d-4292d709fae3">Buckley Hall</option>
+                <option value="11b3613e-105c-48da-9f98-85678059785f">Bullingdon (Convicted Only)</option>
+                <option value="8c920312-ea31-45a2-aec8-e18d642567d6">Bullingdon (Remand Only)</option>
+                <option value="ff6eb0ca-da69-4495-ac9d-b383e01371eb">Bure</option>
+                <option value="0614760e-a773-49c0-a29c-35e743e72555">Cardiff</option>
+                <option value="4d4c2f39-a7a1-4295-9cd1-f4ab416f4508">Channings Wood</option>
+                <option value="6114c49b-0fb2-403d-bac3-b960767adf0d">Chelmsford</option>
+                <option value="a207122a-8ac8-4afe-821f-35a421a2fb52">Coldingley</option>
+                <option value="4464d460-6307-4085-bd76-7ea8d64f3c86">Cookham Wood</option>
+                <option value="21c6d486-280d-4426-a1e4-7b264613dcc7">Dartmoor</option>
+              </Select>
             </FormGroup>
             <FormGroup>
               <Button onClick={handleSubmit}>Continue</Button>


### PR DESCRIPTION
User Story:
As a user managing the contact details of prisoners, I want to add a Date of Birth field in the UK format (DD/MM/YYYY), so that I can accurately record the birth dates of the prisoners in a consistent and clear manner.

Acceptance Criteria:
- The contact details form must include a new field labeled "Date of Birth".
- This field should display placeholder text or a label indicating the date format as "DD/MM/YYYY".
- The form should not accept dates that are not in the UK date format.
- The date of birth field should include a date picker to facilitate correct date selection.
- Users should be able to manually enter a date in the date of birth field using their keyboard with validation to ensure it is the correct format.
- The form should validate that the entered date is a valid calendar date (not allowing dates like 31/02/YYYY).
- The date of birth field should reject any entries with future dates to ensure the date of birth is in the past.
- Upon submission, if the date of birth field is not filled out correctly in the UK date format, the user should receive a clear error message prompting the correct format.
- The system should store and handle the date of birth data correctly in the backend, keeping the UK format.
- Ensure the date of birth field is accessible, including support for screen readers and keyboard navigation.

Please ensure all acceptance criteria are met before marking this development ticket as completed.