### PR TITLE
MKCD-108

### DIFF
--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -19,27 +19,30 @@ import { useForm } from '@formspree/react';
 
 export default function FirstPage() {
   // Define a translations object
-const translations = {
-    pageTitle: "Visit Someone in Prison",
-    prisonerDetailsHeading: "Prisoner Details",
-    firstNameLabel: "Prisoner First Name",
-    lastNameLabel: "Prisoner Last Name",
-    prisonerNumberLabel: "Prisoner Number",
-    prisonerNumberHint: "For example, A1234BC",
-    prisonNameLabel: "Prison Name",
-    prisonNameHint: "For example, Cardiff",
-    selectPrisonPlaceholder: "Select a Prison",
-    bullingdonConvicted: "Bullingdon (Convicted Only)",
-    bullingdonRemand: "Bullingdon (Remand Only)",
-    continueButton: "Continue",
-    enterFirstName: "Please enter a first name",
-    enterLastName: "Please enter a last name",
-    enterPrisonName: "Please enter a prison name",
-    enterValidPrisonerNumber: "Please enter a correctly formatted prisoner number",
-    enterPrisonerNumber: "Please enter a prisoner number",
-    dobLabel: "Prisoner's Date of Birth",
-    enterValidDob: "Please enter a valid date of birth (yyyy-mm-dd)"
-};
+  const translations = {
+    pageTitle: "Visiter quelqu'un en prison",
+    prisonerDetailsHeading: "Details du detenu",
+    firstNameLabel: "Prenom du detenu",
+    lastNameLabel: "Nom de famille du detenu",
+    prisonerNumberLabel: "Numero de detenu",
+    prisonerNumberHint: "Par exemple, A1234BC",
+    prisonNameLabel: "Nom de la prison",
+    prisonNameHint: "Par exemple, Cardiff",
+    selectPrisonPlaceholder: "Selectionnez une prison",
+    // List of prisons can also be translated
+    bullingdonConvicted: "Bullingdon (condamne seulement)",
+    bullingdonRemand: "Bullingdon (garde a vue seulement)",
+    continueButton: "Continuer",
+    // Validation messages
+    enterFirstName: "Veuillez entrer un prenom",
+    enterLastName: "Veuillez entrer un nom de famille",
+    enterPrisonName: "Veuillez entrer un nom de prison",
+    enterValidPrisonerNumber: "Veuillez entrer un numero de detenu correctement formate",
+    enterPrisonerNumber: "Veuillez entrer un numÃ©ro de detenu",
+    // Date of Birth field if added
+    dobLabel: "Date de naissance du detenu",
+    enterValidDob: "Veuillez entrer une date de naissance valide (aaaa-mm-jj)"
+  };
 
   const imageURL = "https://oaidalleapiprodscus.blob.core.windows.net/private/org-aGEVVU5tg2M2AsgFnKKY8QJR/user-fcv2C4iR96qYVhGJaLfvBrFl/img-NU5xcJIOtukL4RMhCr5cNkL9.png?st=2023-12-05T14%3A23%3A14Z&se=2023-12-05T16%3A23%3A14Z&sp=r&sv=2021-08-06&sr=b&rscd=inline&rsct=image/png&skoid=6aaadede-4fb3-4698-a8f6-684d7786b067&sktid=a48cca56-e6da-484e-a814-9c849652bcb3&skt=2023-12-05T13%3A34%3A06Z&ske=2023-12-06T13%3A34%3A06Z&sks=b&skv=2021-08-06&sig=NWXuzd28QPLZyXKuLt5T1PSG52tj8XOf7TLDZgyxY6M%3D"
   const snowGIFUrl = "https://i.pinimg.com/originals/8b/30/71/8b3071feeff83f1e4a63ed231562ff0c.gif"


### PR DESCRIPTION
User story: As a French-speaking user, I want the contact details form to be available in French so that I can easily understand and submit my contact information without experiencing a language barrier.

Acceptance Criteria:
- All static text on the contact details form, including field labels (e.g., "Name," "Address," "Phone number," etc.), instructions, button labels, and error messages, should be translated into French.
- The translation should be contextually accurate and the tone should remain professional to maintain the formality of a contact submission.
- The form should provide an option to switch between English and French, preserving any information already entered when changing languages.
- After translation, the form should be tested with native French speakers to ensure that all translations are clear, understandable, and free from grammatical errors or colloquialisms that could lead to confusion.